### PR TITLE
Fixes deadlock at kill_cmd and execute_cmd

### DIFF
--- a/frida_push/command.py
+++ b/frida_push/command.py
@@ -154,8 +154,8 @@ def push_and_execute(fname, transport_id=None):
 
     push_cmd = [ADB_PATH, "-t", transport_id, "push", fname, "/data/local/tmp/frida-server"]
     chmod_cmd = [ADB_PATH, "-t", transport_id, "shell", "chmod 0755 /data/local/tmp/frida-server"]
-    kill_cmd = [ADB_PATH, "-t", transport_id, "shell", "su 0 killall frida-server"]
-    execute_cmd = [ADB_PATH, "-t", transport_id, "shell", "su 0 '/data/local/tmp/frida-server'"]
+    kill_cmd = [ADB_PATH, "-t", transport_id, "shell", "su", "-c", "killall", "frida-server"]
+    execute_cmd = [ADB_PATH, "-t", transport_id, "shell", "su", "-c", "/data/local/tmp/frida-server"]
 
     res = subprocess.Popen(push_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     res.wait()


### PR DESCRIPTION
I don't know the particular reason in which the old command wasn't working, but it was deadlocking on the `Popen(kill_cmd)` line. Even spawning the command on a `adb shell` did not work. If I'd to guess, maybe something related to newer devices, SDK versions, etc.?

Notwithstanding, it seems to me that the proposed implementation is more robust, at least based on the little knowledge I have :)